### PR TITLE
!resetfleet command

### DIFF
--- a/SeaOfThieves_Rework/Bot.cs
+++ b/SeaOfThieves_Rework/Bot.cs
@@ -682,11 +682,6 @@ namespace SeaOfThieves
         public ulong FleetLobby;
 
         /// <summary>
-        ///     Начальное количество пользователей в канале лобби рейдов.
-        /// </summary>
-        public int FleetLobbyLimiter;
-
-        /// <summary>
         ///     Начальное количество пользователей в канале рейда.
         /// </summary>
         public int FleetUserLimiter;

--- a/SeaOfThieves_Rework/Bot.cs
+++ b/SeaOfThieves_Rework/Bot.cs
@@ -665,6 +665,32 @@ namespace SeaOfThieves
         /// </summary>
         public ulong WaitingRoom;
 
+       
+        /// <summary>
+        ///     ID категории рейдов.
+        /// </summary>
+        public ulong FleetCategory;
+
+        /// <summary>
+        ///     ID канала Chill в категории рейдов.
+        /// </summary>
+        public ulong FleetChillChannel;
+
+        /// <summary>
+        ///     ID канала лобби в категории рейдов.
+        /// </summary>
+        public ulong FleetLobby;
+
+        /// <summary>
+        ///     Начальное количество пользователей в канале лобби рейдов.
+        /// </summary>
+        public int FleetLobbyLimiter;
+
+        /// <summary>
+        ///     Начальное количество пользователей в канале рейда.
+        /// </summary>
+        public int FleetUserLimiter;
+
         /// <summary>
         ///     Путь до XML-файла с приватными кораблями.
         /// </summary>

--- a/SeaOfThieves_Rework/Commands/UtilsCommands.cs
+++ b/SeaOfThieves_Rework/Commands/UtilsCommands.cs
@@ -253,6 +253,7 @@ namespace SeaOfThieves.Commands
                     }
                     else
                         await fleetChannel.ModifyAsync(name: "Общий", user_limit: 0);
+            await ctx.RespondAsync($"{Bot.BotSettings.OkEmoji} Успешно сброшены каналы рейда!");
         }
 
         [Command("codexgen")]

--- a/SeaOfThieves_Rework/Commands/UtilsCommands.cs
+++ b/SeaOfThieves_Rework/Commands/UtilsCommands.cs
@@ -245,15 +245,14 @@ namespace SeaOfThieves.Commands
             
             int i = 1;
             foreach (var fleetChannel in ctx.Guild.GetChannel(Bot.BotSettings.FleetCategory).Children)
-                if (fleetChannel.Type == ChannelType.Voice)
-                    if (fleetChannel.Id != Bot.BotSettings.FleetChillChannel) //Учитываем присутствие канала Chill
-                        if (fleetChannel.Id != Bot.BotSettings.FleetLobby) //Лобби рейда
-                        {
-                            await fleetChannel.ModifyAsync(name: $"Рейд#{i}", user_limit: Bot.BotSettings.FleetUserLimiter);
-                            i++;
-                        }
-                        else
-                            await fleetChannel.ModifyAsync(name: "Общий", user_limit: Bot.BotSettings.FleetLobbyLimiter);
+                if (fleetChannel.Type == ChannelType.Voice && fleetChannel.Id != Bot.BotSettings.FleetChillChannel) //Убираем из списка очистки текстовые каналы и голосовой канал Chill
+                    if (fleetChannel.Id != Bot.BotSettings.FleetLobby) //Учитываем присутствие канала лобби
+                    {
+                        await fleetChannel.ModifyAsync(name: $"Рейд#{i}", user_limit: Bot.BotSettings.FleetUserLimiter);
+                        i++;
+                    }
+                    else
+                        await fleetChannel.ModifyAsync(name: "Общий", user_limit: 0);
         }
 
         [Command("codexgen")]

--- a/SeaOfThieves_Rework/Commands/UtilsCommands.cs
+++ b/SeaOfThieves_Rework/Commands/UtilsCommands.cs
@@ -233,6 +233,29 @@ namespace SeaOfThieves.Commands
             await ctx.Message.DeleteAsync();
         }
 
+        [Command("resetfleet")] //TODO: Проверить если работает корректно, так как не знаю какими правами обладают рейдеры и какие настройки каналов на сервере
+        [Hidden]
+        public async Task ResetFleetChannels(CommandContext ctx) //Команда для сброса названий и слотов каналов рейда после "рейдеров"
+        {
+            if (!Bot.IsModerator(ctx.Member)) //Проверка на права модератора. (копипаст с команды clearchannel)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} У вас нет доступа к этой команде!");
+                return;
+            }
+            
+            int i = 1;
+            foreach (var fleetChannel in ctx.Guild.GetChannel(Bot.BotSettings.FleetCategory).Children)
+                if (fleetChannel.Type == ChannelType.Voice)
+                    if (fleetChannel.Id != Bot.BotSettings.FleetChillChannel) //Учитываем присутствие канала Chill
+                        if (fleetChannel.Id != Bot.BotSettings.FleetLobby) //Лобби рейда
+                        {
+                            await fleetChannel.ModifyAsync(name: $"Рейд#{i}", user_limit: Bot.BotSettings.FleetUserLimiter);
+                            i++;
+                        }
+                        else
+                            await fleetChannel.ModifyAsync(name: "Общий", user_limit: Bot.BotSettings.FleetLobbyLimiter);
+        }
+
         [Command("codexgen")]
         [RequirePermissions(Permissions.Administrator)]
         public async Task CodexGenerateMessage(CommandContext ctx)

--- a/SeaOfThieves_Rework/settings.example.xml
+++ b/SeaOfThieves_Rework/settings.example.xml
@@ -20,6 +20,12 @@
     <Bitrate>48000</Bitrate>
     <FastCooldown>30</FastCooldown>
     <WaitingRoom>496614051728588804</WaitingRoom>
+
+    <FleetCategory>699687487743721503</FleetCategory>
+    <FleetChillChannel>699688642238611531</FleetChillChannel>
+    <FleetLobby>699688711226392657</FleetLobby>
+    <FleetLobbyLimiter>99</FleetLobbyLimiter>
+    <FleetUserLimiter>5</FleetUserLimiter>
     
     <ShipXML>ships.xml</ShipXML>
     <PrivateCategory>435448014614822923</PrivateCategory>

--- a/SeaOfThieves_Rework/settings.example.xml
+++ b/SeaOfThieves_Rework/settings.example.xml
@@ -24,7 +24,6 @@
     <FleetCategory>699687487743721503</FleetCategory>
     <FleetChillChannel>699688642238611531</FleetChillChannel>
     <FleetLobby>699688711226392657</FleetLobby>
-    <FleetLobbyLimiter>99</FleetLobbyLimiter>
     <FleetUserLimiter>5</FleetUserLimiter>
     
     <ShipXML>ships.xml</ShipXML>


### PR DESCRIPTION
Allow moderators to reset and clean channels in fleet category

Позволяет производить чистку каналов в рейде после "рейдеров" с помощью `!resetfleet`

Команда только переименовывает и изменяет кл.во слотов в комнате не трогая остальные параметры 

Нужно добавить еще один канал: "**Общий**" для сбора рейда

**Пример до:**
![Before](https://user-images.githubusercontent.com/12542642/79271807-b5e87900-7ea0-11ea-8def-79f61cef8f61.JPG)

**После:**
![After](https://user-images.githubusercontent.com/12542642/79271811-b7b23c80-7ea0-11ea-93fe-802775e16a22.JPG)

p.s. В этот раз код тестился

Возможен только баг связанный с тем что каналы не указанные в конфиге по id будут по наростающей изменяться на Рейд#`[X]`